### PR TITLE
double fix coalescing.cu

### DIFF
--- a/series/cuda-cpp/coalescing-global/coalescing.cu
+++ b/series/cuda-cpp/coalescing-global/coalescing.cu
@@ -51,7 +51,7 @@ void runTest(int deviceId, int nMB)
   offset<<<n/blockSize, blockSize>>>(d_a, 0); // warm up
 
   for (int i = 0; i <= 32; i++) {
-    checkCuda( cudaMemset(d_a, 0.0, n * sizeof(T)) );
+    checkCuda( cudaMemset(d_a, 0, n * sizeof(T)) );
 
     checkCuda( cudaEventRecord(startEvent,0) );
     offset<<<n/blockSize, blockSize>>>(d_a, i);
@@ -67,7 +67,7 @@ void runTest(int deviceId, int nMB)
 
   stride<<<n/blockSize, blockSize>>>(d_a, 1); // warm up
   for (int i = 1; i <= 32; i++) {
-    checkCuda( cudaMemset(d_a, 0.0, n * sizeof(T)) );
+    checkCuda( cudaMemset(d_a, 0, n * sizeof(T)) );
 
     checkCuda( cudaEventRecord(startEvent,0) );
     stride<<<n/blockSize, blockSize>>>(d_a, i);


### PR DESCRIPTION
Here:
https://github.com/parallel-forall/code-samples/blob/master/series/cuda-cpp/coalescing-global/coalescing.cu

lines 54 and 70 are passing a double for the second argument:

```
checkCuda( cudaMemset(d_a, 0.0, n * sizeof(T)) );
```

This is not really sensible and may trigger compiler warnings like this:

coalescing.cu:70: warning: passing âdoubleâ for argument 2 to âcudaError_t cudaMemset(void*, int, size_t)â

I would recommend changing those 2 instances of 0.0 to just 0
I guess there is also a fix  for "no newline at end of file" which may have been inserted by my editor
