### PR TITLE
Fixing flags to render to FBO by default

### DIFF
--- a/posts/egl_OpenGl_without_Xserver/tinyegl.cc
+++ b/posts/egl_OpenGl_without_Xserver/tinyegl.cc
@@ -28,7 +28,15 @@
 #include <EGL/eglext.h>
 #endif
 
+#ifdef USE_EGL_SURFACE
 #include <GL/gl.h>
+#else
+#define GL_GLEXT_PROTOTYPES
+#include <GL/gl.h>
+#include <GL/glext.h>
+#endif
+
+
 
   static const EGLint configAttribs[] = {
           EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
@@ -50,14 +58,6 @@
         EGL_NONE,
   };
 
-
-// use eglGetDisplay or device/platform extensions to select display
-#define USE_EGL_GET_DISPLAY
-//#undef USE_EGL_GET_DISPLAY
-
-// use egl surface or manually managed FBO as render target
-#define USE_EGL_SURFACE
-//#undef USE_EGL_SURFACE
 
 int main(int argc, char *argv[])
 {

--- a/posts/egl_OpenGl_without_Xserver/tinyegl.cc
+++ b/posts/egl_OpenGl_without_Xserver/tinyegl.cc
@@ -16,8 +16,8 @@
 //#undef USE_EGL_GET_DISPLAY
 
 // use egl surface or manually managed FBO as render target
-#define USE_EGL_SURFACE
-//#undef USE_EGL_SURFACE
+//#define USE_EGL_SURFACE
+#undef USE_EGL_SURFACE
 
 
 #ifdef USE_EGL_GET_DISPLAY


### PR DESCRIPTION
The previous version didn't accurately handle the different configuration flags (USE_EGL_GET_DISPLAY, USE_EGL_SURFACE). This is fixed now. In addition, the default is set to FBO rendering, instead of using EGL_SURFACE. 
