### PR TITLE
Resolution of function names in profiler timeline.

### DIFF
--- a/posts/nvtx/Makefile
+++ b/posts/nvtx/Makefile
@@ -38,7 +38,7 @@ inst_nvtx.o: inst_nvtx.cpp Makefile
 manual_nvtx: manual_nvtx.cu Makefile
 	nvcc -Xcompiler -export-dynamic -DUSE_NVTX -arch=sm_20 -lnvToolsExt -o manual_nvtx manual_nvtx.cu
 
-compiler_inst_nvtx: compiler_inst_nvtx1.cu Makefile inst_nvtx.o
+compiler_inst_nvtx: compiler_inst_nvtx.cu Makefile inst_nvtx.o
 	nvcc -Xcompiler -export-dynamic -Xcompiler -fPIC -Xcompiler -finstrument-functions -arch=sm_20 inst_nvtx.o -ldl -lnvToolsExt -o compiler_inst_nvtx compiler_inst_nvtx1.cu 
 	
 clean:

--- a/posts/nvtx/Makefile
+++ b/posts/nvtx/Makefile
@@ -39,7 +39,7 @@ manual_nvtx: manual_nvtx.cu Makefile
 	nvcc -Xcompiler -export-dynamic -DUSE_NVTX -arch=sm_20 -lnvToolsExt -o manual_nvtx manual_nvtx.cu
 
 compiler_inst_nvtx: compiler_inst_nvtx1.cu Makefile inst_nvtx.o
-	nvcc -G -Xcompiler -export-dynamic -Xcompiler -fPIC -Xcompiler -finstrument-functions -arch=sm_20 inst_nvtx.o -ldl -lnvToolsExt -o compiler_inst_nvtx compiler_inst_nvtx1.cu 
+	nvcc -Xcompiler -export-dynamic -Xcompiler -fPIC -Xcompiler -finstrument-functions -arch=sm_20 inst_nvtx.o -ldl -lnvToolsExt -o compiler_inst_nvtx compiler_inst_nvtx1.cu 
 	
 clean:
 	rm -f *.o $(BINARIES)

--- a/posts/nvtx/Makefile
+++ b/posts/nvtx/Makefile
@@ -33,13 +33,13 @@ BINARIES=manual_nvtx compiler_inst_nvtx
 all: $(BINARIES)
 
 inst_nvtx.o: inst_nvtx.cpp Makefile
-	g++ -fPIC -I${CUDA_ROOT}/include -c inst_nvtx.cpp
+	g++ -export-dynamic -fPIC -I${CUDA_ROOT}/include -c inst_nvtx.cpp
 
 manual_nvtx: manual_nvtx.cu Makefile
-	nvcc -DUSE_NVTX -arch=sm_20 -lnvToolsExt -o manual_nvtx manual_nvtx.cu
+	nvcc -Xcompiler -export-dynamic -DUSE_NVTX -arch=sm_20 -lnvToolsExt -o manual_nvtx manual_nvtx.cu
 
-compiler_inst_nvtx: compiler_inst_nvtx.cu Makefile inst_nvtx.o
-	nvcc -Xcompiler -fPIC -Xcompiler -finstrument-functions -arch=sm_20 inst_nvtx.o -ldl -lnvToolsExt -o compiler_inst_nvtx compiler_inst_nvtx.cu 
+compiler_inst_nvtx: compiler_inst_nvtx1.cu Makefile inst_nvtx.o
+	nvcc -G -Xcompiler -export-dynamic -Xcompiler -fPIC -Xcompiler -finstrument-functions -arch=sm_20 inst_nvtx.o -ldl -lnvToolsExt -o compiler_inst_nvtx compiler_inst_nvtx1.cu 
 	
 clean:
 	rm -f *.o $(BINARIES)


### PR DESCRIPTION
Changed Makefile to compile the host code with -export-dynamic flag. This is necessary for the resolution of function names in compiler instrumented entry and exit functions.