### PR TITLE
[patch v2] jacobee: Allow compilation of code with cuda

### DIFF
--- a/posts/cuda-aware-mpi-example/src/Makefile
+++ b/posts/cuda-aware-mpi-example/src/Makefile
@@ -40,8 +40,11 @@ GENCODE_SM30    := -gencode arch=compute_30,code=sm_30
 GENCODE_SM35    := -gencode arch=compute_35,code=sm_35
 GENCODE_SM35    := -gencode arch=compute_37,code=sm_37
 GENCODE_SM50    := -gencode arch=compute_50,code=sm_50
-GENCODE_SM52    := -gencode arch=compute_52,code=\"sm_52,compute_52\"
-GENCODE_FLAGS   := $(GENCODE_SM20) $(GENCODE_SM30) $(GENCODE_SM35) $(GENCODE_SM37) $(GENCODE_SM50) $(GENCODE_SM52)
+GENCODE_SM52    := -gencode arch=compute_52,code=sm_52
+GENCODE_SM60    := -gencode arch=compute_60,code=sm_60
+GENCODE_SM70    := -gencode arch=compute_70,code=\"sm_70,compute_70\"
+GENCODE_FLAGS   := $(GENCODE_SM20) $(GENCODE_SM30) $(GENCODE_SM35)             \
+$(GENCODE_SM37) $(GENCODE_SM50) $(GENCODE_SM52) $(GENCODE_SM60) $(GENCODE_SM70)
 
 NVCCFLAGS=-O3 $(GENCODE_FLAGS) -Xcompiler -march=native
 
@@ -66,7 +69,7 @@ jacobi.o: Jacobi.h Jacobi.c Makefile
 	$(MPICC) $(MPICFLAGS) $(CUDACFLAGS) $(CFLAGS) -c Jacobi.c -o jacobi.o
 
 host.o: Jacobi.h Host.c Makefile
-	$(MPICC) $(MPICFLAGS) $(CFLAGS) -c Host.c -o host.o
+	$(MPICC) $(MPICFLAGS) $(CFLAGS) $(CUDACFLAGS) -c Host.c -o host.o
 
 cuda_normal_mpi.o: Jacobi.h CUDA_Normal_MPI.c Makefile
 	$(MPICC) $(MPICFLAGS) $(CFLAGS) $(CUDACFLAGS) -c CUDA_Normal_MPI.c -o cuda_normal_mpi.o
@@ -76,11 +79,11 @@ cuda_aware_mpi.o: Jacobi.h CUDA_Aware_MPI.c Makefile
 
 $(JACOBI_CUDA_NORMAL_MPI): jacobi.o input.o host.o device.o cuda_normal_mpi.o Makefile
 	mkdir -p $(BINDIR)
-	$(MPILD) $(CUDALDFLAGS) -o $(JACOBI_CUDA_NORMAL_MPI) jacobi.o input.o host.o device.o  cuda_normal_mpi.o  
+	$(MPILD) -o $(JACOBI_CUDA_NORMAL_MPI) jacobi.o input.o host.o device.o  cuda_normal_mpi.o $(CUDALDFLAGS)
 	
 $(JACOBI_CUDA_AWARE_MPI): jacobi.o input.o host.o device.o cuda_aware_mpi.o Makefile
 	mkdir -p $(BINDIR)
-	$(MPILD) $(CUDALDFLAGS) -o $(JACOBI_CUDA_AWARE_MPI) jacobi.o input.o host.o device.o cuda_aware_mpi.o  
+	$(MPILD) -o $(JACOBI_CUDA_AWARE_MPI) jacobi.o input.o host.o device.o cuda_aware_mpi.o $(CUDALDFLAGS)
 
 doc: CUDA_Normal_MPI.c CUDA_Aware_MPI.c Device.cu Host.c Input.c Makefile Jacobi.c Jacobi.h Jacobi.doxygen
 	doxygen Jacobi.doxygen


### PR DESCRIPTION
There is a bug in Makefile when specifying LD flags.
Fixing the same in this patch. This patch also addresses CUDA 9 and Volta.

Signed-off-by: Devesh Sharma <devesh.sharma@broadcom.com>