### PR TITLE
Fix shared memory Table size and accesses reporting in GUPS benchmark

### DIFF
--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -484,14 +484,30 @@ int main(int argc, char* argv[])
   }
   size_t total_num_thread = thread * grid;
 
-  printf(
-      "Table size = %zu (%lf GB.)\nTotal number of threads %zu\nEach thread "
-      "access %d locations.\nNumber of iterations = %d\n",
-      working_set,
-      working_set * sizeof(benchtype) / 1e9,
-      total_num_thread,
-      accesses_per_elem,
-      repeats);
+  if (!shared_mem) {
+    printf(
+        "Table size = %zu (%lf GB.)\nTotal number of threads %zu\nEach thread "
+        "access %d locations.\nNumber of iterations = %d\n",
+        working_set,
+        working_set * sizeof(benchtype) / 1e9,
+        total_num_thread,
+        accesses_per_elem,
+        repeats);
+  } else {
+    // For shared memory tests, report the actual shared memory used
+    size_t total_shmem = grid * n_shmem * sizeof(benchtype);
+    printf(
+        "Table size = %zu (%lf MB.) [shared memory: %zu bytes per block x %zu blocks]\n"
+        "Total number of threads %zu\nEach thread "
+        "access %d locations.\nNumber of iterations = %d\n",
+        total_shmem / sizeof(benchtype),
+        total_shmem / 1e6,
+        n_shmem * sizeof(benchtype),
+        grid,
+        total_num_thread,
+        accesses_per_elem_sh,
+        repeats);
+  }
 
   benchtype* d_t;
   if (!shared_mem)

--- a/posts/gups/gups.cu
+++ b/posts/gups/gups.cu
@@ -494,7 +494,6 @@ int main(int argc, char* argv[])
         accesses_per_elem,
         repeats);
   } else {
-    // For shared memory tests, report the actual shared memory used
     size_t total_shmem = grid * n_shmem * sizeof(benchtype);
     printf(
         "Table size = %zu (%lf MB.) [shared memory: %zu bytes per block x %zu blocks]\n"


### PR DESCRIPTION
## Summary
This PR fixes the incorrect Table size and accesses per thread reporting for shared memory tests in the GUPS benchmark, addressing the issues raised by @rkarim2 in #56.

## Problem
Previously, when running shared memory tests, the benchmark incorrectly reported:
- Table size showed the global memory working set size (e.g., 4.2 GB), which was irrelevant for shared memory tests
- Number of accesses per thread used the global memory value instead of the shared memory-specific value

## Solution
- **Table size for shared memory**: Now correctly shows the actual total shared memory used across all blocks (`grid * n_shmem * sizeof(benchtype)`)
- **Clear details**: Added breakdown showing bytes per block × number of blocks for transparency
- **Correct accesses count**: Uses `accesses_per_elem_sh` for shared memory tests instead of `accesses_per_elem`
- **Appropriate units**: Reports shared memory size in MB (more suitable scale) vs GB for global memory

## Example output
### Before:
```
Table size = 536870912 (4.294967 GB.)
Each thread access 8 locations.
```

### After:
```
Table size = 12288 (0.098304 MB.) [shared memory: 49152 bytes per block x 2 blocks]
Each thread access 65536 locations.
```

## Testing
- Code compiles successfully with `make clean && make`
- Shared memory tests now display correct memory sizes and access counts
- Global memory tests remain unchanged and work as before

Addresses the confusion mentioned in #56 about the misleading Table size output for shared memory tests.

*Note: This is a clean PR with only the relevant changes, created from the latest master branch.*